### PR TITLE
Define custom width and height of the board

### DIFF
--- a/gacela.php
+++ b/gacela.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types = 1);
+
+use Gacela\Framework\Bootstrap\GacelaConfig;
+
+return static function (GacelaConfig $config): void {
+    $config->setFileCacheEnabled(true);
+};

--- a/play.php
+++ b/play.php
@@ -6,7 +6,7 @@ require_once __DIR__ . "/vendor/autoload.php";
 
 $compiledFile = __DIR__ . "/out/phel_snake/game.php";
 if (!file_exists($compiledFile)) {
-    exit('You have to compile the game first. Try with: `composer compile`');
+    exec('vendor/bin/phel compile --no-cache');
 }
 
 require_once $compiledFile;

--- a/src/game.phel
+++ b/src/game.phel
@@ -17,6 +17,9 @@
   "The higher the faster it will increase the speed on each level."
   10000)
 
+(php/dd argv) # 42
+(def board-width (extract-value-from-arg argv "width" 42))
+(def board-height (extract-value-from-arg argv "height" 22))
 (def debug? (php/in_array "debug" argv))
 (def nano-seconds-delay-base 140000)
 (def start-time (php/microtime true))
@@ -70,7 +73,8 @@
 
 (defn main []
   (gui/clear-screen)
-  (loop [board {:width 42 :height 22}
+#  (loop [board {:width 42 :height 22}
+  (loop [board {:width board-width :height board-height}
          snake {:direction :right
                 :speed 1
                 :head (generate-snake-head board)

--- a/src/game.phel
+++ b/src/game.phel
@@ -7,7 +7,8 @@
                                      move-snake
                                      update-goal
                                      collision-with-board?
-                                     grow-snake]))
+                                     grow-snake
+                                     extract-value-from-arg]))
 
 (gui/add-output-formatter {:style-name "snake-head" :foreground "black" :background "red" :options ["bold"]})
 (gui/add-output-formatter {:style-name "snake-tail" :foreground "black" :background "green" :options ["bold"]})
@@ -17,7 +18,6 @@
   "The higher the faster it will increase the speed on each level."
   10000)
 
-(php/dd argv) # 42
 (def board-width (extract-value-from-arg argv "width" 42))
 (def board-height (extract-value-from-arg argv "height" 22))
 (def debug? (php/in_array "debug" argv))
@@ -73,7 +73,6 @@
 
 (defn main []
   (gui/clear-screen)
-#  (loop [board {:width 42 :height 22}
   (loop [board {:width board-width :height board-height}
          snake {:direction :right
                 :speed 1

--- a/src/game.phel
+++ b/src/game.phel
@@ -17,7 +17,7 @@
   "The higher the faster it will increase the speed on each level."
   10000)
 
-(def debug? false)
+(def debug? (php/in_array "debug" argv))
 (def nano-seconds-delay-base 140000)
 (def start-time (php/microtime true))
 (def goal-icon {:text " " :style "goal"})

--- a/src/logic.phel
+++ b/src/logic.phel
@@ -68,5 +68,7 @@
     goal))
 
 (defn extract-value-from-arg [args key default]
-    default
-  )
+  (let [arg (find |(php/str_contains $ key) args)]
+    (if (empty? arg)
+        default
+        (php/intval (get (php/explode "=" arg) 1)))))

--- a/src/logic.phel
+++ b/src/logic.phel
@@ -67,3 +67,6 @@
     (generate-new-goal board)
     goal))
 
+(defn extract-value-from-arg [args key default]
+    default
+  )

--- a/tests/logic-test.phel
+++ b/tests/logic-test.phel
@@ -1,7 +1,8 @@
 (ns phel-snake-tests\logic-test
   (:require phel-snake\logic :refer [snake-reach-goal?
                                      move-snake
-                                     collision-with-board?])
+                                     collision-with-board?
+                                     extract-value-from-arg])
   (:require phel\test :refer [deftest is]))
 
 (deftest test-move-snake
@@ -41,3 +42,8 @@
     (is (true?  (collision-with-board? board {:head {:x 5 :y 9}})) "collision on right")
     (is (true?  (collision-with-board? board {:head {:x 10 :y 5}})) "collision on bottom")
     (is (true?  (collision-with-board? board {:head {:x 0 :y 5}})) "collision on left")))
+
+(deftest test-extract-value-from-arg
+  (is (= 10 (extract-value-from-arg [] "key" 10)) "default value")
+#  (is (5 (extract-value-from-arg ["key=5"] "key" 10)) "defined value")
+  )

--- a/tests/logic-test.phel
+++ b/tests/logic-test.phel
@@ -44,6 +44,6 @@
     (is (true?  (collision-with-board? board {:head {:x 0 :y 5}})) "collision on left")))
 
 (deftest test-extract-value-from-arg
-  (is (= 10 (extract-value-from-arg [] "key" 10)) "default value")
-#  (is (5 (extract-value-from-arg ["key=5"] "key" 10)) "defined value")
-  )
+  (is (= 10 (extract-value-from-arg [] "key" 10)) "empty args results in default value")
+  (is (= 10 (extract-value-from-arg ["unknown=2"] "key" 10)) "unknown key results in default value")
+  (is (= 5 (extract-value-from-arg ["unknown=2" "key=5"] "key" 10)) "defined key results in defined value"))


### PR DESCRIPTION
## 📚 Description

Allow adding additional arguments when running the script:
- debug
- width=N
- height=N

E.g:
```bash
vendor/bin/phel run src/game.phel width=60 height=45 debug
```

<img width="1787" alt="Screenshot 2022-12-17 at 18 40 18" src="https://user-images.githubusercontent.com/5256287/208254429-d9e05f34-7a99-4f56-99a7-f86b21b08126.png">
