### PR TITLE
Optimize rendering

### DIFF
--- a/src/game.phel
+++ b/src/game.phel
@@ -64,14 +64,11 @@
   (println (format "Speed: %d" (count (snake :tail))))
   (println (playing-time)))
 
-(defstruct board [width height])
-(defstruct snake [direction speed head tail])
-
 (defn main []
   (gui/clear-screen)
-  (loop [b (board board-width board-height)
+  (loop [b (l/board board-width board-height)
          s {:old {}
-            :new (snake :right 1 (l/generate-snake-head b) [])}
+            :new (l/snake :right 1 (l/generate-snake-head b) [])}
          goal (l/generate-new-goal b)]
 
     (sleep-delay (s :new))
@@ -81,7 +78,7 @@
     (let [{:hex in} (gui/read-input 3)
           next-direction (l/normalize-next-direction in)
           updated-goal (l/update-goal (s :new) goal b)
-          updated-snake (l/move-snake (s :new) next-direction)]
+          updated-snake (l/move-snake s next-direction)]
 
       (if (l/collision-with-board? b (s :new))
         (render-game-over b (s :new)))

--- a/src/game.phel
+++ b/src/game.phel
@@ -69,7 +69,7 @@
   (loop [b (l/board board-width board-height)
          s {:old {}
             :new (l/snake :right 1 (l/generate-snake-head b) [])}
-         goal (l/generate-new-goal b)]
+         g (l/generate-new-goal b)]
 
     (sleep-delay (s :new))
     (gui/clear-output)
@@ -77,7 +77,7 @@
 
     (let [{:hex in} (gui/read-input 3)
           next-direction (l/normalize-next-direction in)
-          g2 (l/update-goal (s :new) goal b)
+          g2 (l/update-goal (s :new) g b)
           s2 (l/move-snake (s :new) next-direction)]
 
       (if (l/collision-with-board? b (s :new))
@@ -88,10 +88,8 @@
       (render-stats b s2)
       (debug-snake b s2)
 
-      (let [new-goal? (not= goal g2)
-            s3 (if new-goal?
-                 (put s2 :speed (inc :speed))
-                 s2)
+      (let [new-goal? (not= g g2)
+            s3 (if new-goal? (update s2 :speed inc) s2)
             s4 (if new-goal? (l/grow-snake s3) s3)]
         (recur b {:old (s :new) :new s4} g2)))))
 

--- a/src/game.phel
+++ b/src/game.phel
@@ -64,26 +64,26 @@
   (println (format "Speed: %d" (count (snake :tail))))
   (println (playing-time)))
 
+(defstruct snake [direction speed head tail])
+
 (defn main []
   (gui/clear-screen)
   (loop [board {:width board-width :height board-height}
-         snake {:direction :right
-                :speed 1
-                :head (l/generate-snake-head board)
-                :tail []}
+         s {:old {}
+            :new (snake :right 1 (l/generate-snake-head board) [])}
          goal (l/generate-new-goal board)]
 
-    (sleep-delay snake)
+    (sleep-delay (s :new))
     (gui/clear-output)
     (gui/render-board board)
 
     (let [{:hex in} (gui/read-input 3)
           next-direction (l/normalize-next-direction in)
-          updated-goal (l/update-goal snake goal board)
-          updated-snake (l/move-snake snake next-direction)]
+          updated-goal (l/update-goal (s :new) goal board)
+          updated-snake (l/move-snake (s :new) next-direction)]
 
-      (if (l/collision-with-board? board snake)
-        (render-game-over board snake))
+      (if (l/collision-with-board? board (s :new))
+        (render-game-over board (s :new)))
 
       (render-snake updated-snake)
       (render-goal updated-goal)
@@ -95,7 +95,7 @@
                  (update updated-snake :speed inc)
                  updated-snake)
             sn2 (if new-goal? (l/grow-snake sn) sn)]
-        (recur board sn2 updated-goal)))))
+        (recur board {:old s :new sn2} updated-goal)))))
 
 (when-not *compile-mode*
   (try

--- a/src/game.phel
+++ b/src/game.phel
@@ -64,38 +64,39 @@
   (println (format "Speed: %d" (count (snake :tail))))
   (println (playing-time)))
 
+(defstruct board [width height])
 (defstruct snake [direction speed head tail])
 
 (defn main []
   (gui/clear-screen)
-  (loop [board {:width board-width :height board-height}
+  (loop [b (board board-width board-height)
          s {:old {}
-            :new (snake :right 1 (l/generate-snake-head board) [])}
-         goal (l/generate-new-goal board)]
+            :new (snake :right 1 (l/generate-snake-head b) [])}
+         goal (l/generate-new-goal b)]
 
     (sleep-delay (s :new))
     (gui/clear-output)
-    (gui/render-board board)
+    (gui/render-board b)
 
     (let [{:hex in} (gui/read-input 3)
           next-direction (l/normalize-next-direction in)
-          updated-goal (l/update-goal (s :new) goal board)
+          updated-goal (l/update-goal (s :new) goal b)
           updated-snake (l/move-snake (s :new) next-direction)]
 
-      (if (l/collision-with-board? board (s :new))
-        (render-game-over board (s :new)))
+      (if (l/collision-with-board? b (s :new))
+        (render-game-over b (s :new)))
 
       (render-snake updated-snake)
       (render-goal updated-goal)
-      (render-stats board updated-snake)
-      (debug-snake board updated-snake)
+      (render-stats b updated-snake)
+      (debug-snake b updated-snake)
 
       (let [new-goal? (not= goal updated-goal)
             sn (if new-goal?
                  (update updated-snake :speed inc)
                  updated-snake)
             sn2 (if new-goal? (l/grow-snake sn) sn)]
-        (recur board {:old s :new sn2} updated-goal)))))
+        (recur b {:old s :new sn2} updated-goal)))))
 
 (when-not *compile-mode*
   (try

--- a/src/game.phel
+++ b/src/game.phel
@@ -23,9 +23,9 @@
 (def snake-head-icon {:text " " :style "snake-head"})
 (def snake-tail-icon {:text " " :style "snake-tail"})
 
-(defn debug-snake [b s]
-  (if debug? (do (gui/clear-line (+ 3 (b :height)))
-                 (let [text (str "$ " b "\n$ " s)]
+(defn debug-snake [board snake]
+  (if debug? (do (gui/clear-line (+ 3 (board :height)))
+                 (let [text (str "$ " board "\n$ " snake)]
                    (println text)))))
 
 (defn sleep-delay [snake]
@@ -35,22 +35,22 @@
                               :left 2 :right 2
                               :up 1 :down 1)
         sleep-time (/ nano-sec velocity-normalizer)]
-    (if debug? (do (println)
+    (if debug? (do (println)(println)(println)
                    (println "# sleep-time:" sleep-time "| velocity-normalizer:" velocity-normalizer)
                    (println)(println)(println "playing...")))
     (php/usleep sleep-time)))
 
-(defn render-snake [s]
-  (for [t :in (s :tail)]
+(defn render-snake [snake]
+  (for [t :in (snake :tail)]
     (gui/render (t :x) (t :y) (snake-tail-icon :text) (snake-tail-icon :style)))
-  (let [h (s :head)]
+  (let [h (snake :head)]
     (gui/render (h :x) (h :y) (snake-head-icon :text) (snake-head-icon :style))))
 
-(defn clear-snake [s]
-  (when-not (nil? (s :tail))
-    (for [t :in (s :tail)]
+(defn clear-snake [snake]
+  (when-not (nil? (snake :tail))
+    (for [t :in (snake :tail)]
       (gui/render (t :x) (t :y) " "))
-    (let [h (s :head)]
+    (let [h (snake :head)]
       (gui/render (h :x) (h :y) " "))))
 
 (defn render-goal [goal]
@@ -65,6 +65,7 @@
     (debug-snake board snake)
     (gui/render x-center y-center game-over-text)
     (gui/render x-center (inc y-center) (format "Points: %d" (snake :speed)))
+    (if debug? (gui/clear-line (+ 3 (board :height))))
     (throw (php/new RuntimeException "\n\nSo much fun!"))))
 
 (defn playing-time []
@@ -75,37 +76,37 @@
   (println (format "Speed: %d" (count (snake :tail))))
   (println (playing-time)))
 
-(def b (l/board board-offset-width board-offset-height board-width board-height))
+(def board (l/board board-offset-width board-offset-height board-width board-height))
 
 (defn main []
   (gui/clear-screen)
-  (gui/render-board b)
+  (gui/render-board board)
 
-  (loop [s {:old {}
-            :new (l/snake :right 1 (l/generate-snake-head b) [])}
-         g (l/generate-new-goal b)]
+  (loop [snake {:old {}
+                :current (l/snake :right 1 (l/generate-snake-head board) [])}
+         goal (l/generate-new-goal board)]
 
-    (sleep-delay (s :new))
+    (sleep-delay (snake :current))
     (gui/clear-output)
 
     (let [{:hex in} (gui/read-input 3)
           next-direction (l/normalize-next-direction in)
-          g2 (l/update-goal (s :new) g b)
-          s2 (l/move-snake (s :new) next-direction)]
+          goal2 (l/update-goal (snake :current) goal board)
+          snake2 (l/move-snake (snake :current) next-direction)]
 
-      (if (l/collision-with-board? b (s :new))
-        (render-game-over b (s :new)))
+      (if (l/collision-with-board? board (snake :current))
+        (render-game-over board (snake :current)))
 
-      (clear-snake (s :old))
-      (render-snake s2)
-      (render-goal g2)
-      (render-stats b s2)
-      (debug-snake b s2)
+      (clear-snake (snake :old))
+      (render-snake snake2)
+      (render-goal goal2)
+      (render-stats board snake2)
+      (debug-snake board snake2)
 
-      (let [new-goal? (not= g g2)
-            s3 (if new-goal? (update s2 :speed inc) s2)
-            s4 (if new-goal? (l/grow-snake s3) s3)]
-        (recur {:old (s :new) :new s4} g2)))))
+      (let [new-goal? (not= goal goal2)
+            snake3 (if new-goal? (update snake2 :speed inc) snake2)
+            snake4 (if new-goal? (l/grow-snake snake3) snake3)]
+        (recur {:old (snake :current) :current snake4} goal2)))))
 
 (when-not *compile-mode*
   (try

--- a/src/game.phel
+++ b/src/game.phel
@@ -77,23 +77,23 @@
 
     (let [{:hex in} (gui/read-input 3)
           next-direction (l/normalize-next-direction in)
-          updated-goal (l/update-goal (s :new) goal b)
-          updated-snake (l/move-snake s next-direction)]
+          g2 (l/update-goal (s :new) goal b)
+          s2 (l/move-snake (s :new) next-direction)]
 
       (if (l/collision-with-board? b (s :new))
         (render-game-over b (s :new)))
 
-      (render-snake updated-snake)
-      (render-goal updated-goal)
-      (render-stats b updated-snake)
-      (debug-snake b updated-snake)
+      (render-snake s2)
+      (render-goal g2)
+      (render-stats b s2)
+      (debug-snake b s2)
 
-      (let [new-goal? (not= goal updated-goal)
-            sn (if new-goal?
-                 (update updated-snake :speed inc)
-                 updated-snake)
-            sn2 (if new-goal? (l/grow-snake sn) sn)]
-        (recur b {:old s :new sn2} updated-goal)))))
+      (let [new-goal? (not= goal g2)
+            s3 (if new-goal?
+                 (put s2 :speed (inc :speed))
+                 s2)
+            s4 (if new-goal? (l/grow-snake s3) s3)]
+        (recur b {:old (s :new) :new s4} g2)))))
 
 (when-not *compile-mode*
   (try

--- a/src/game.phel
+++ b/src/game.phel
@@ -36,11 +36,18 @@
                    (println)(println)(println "playing...")))
     (php/usleep sleep-time)))
 
-(defn render-snake [snake]
-  (for [t :in (snake :tail)]
+(defn render-snake [s]
+  (for [t :in (s :tail)]
     (gui/render (t :x) (t :y) (snake-tail-icon :text) (snake-tail-icon :style)))
-  (let [head (snake :head)]
-    (gui/render (head :x) (head :y) (snake-head-icon :text) (snake-head-icon :style))))
+  (let [h (s :head)]
+    (gui/render (h :x) (h :y) (snake-head-icon :text) (snake-head-icon :style))))
+
+(defn clear-snake [s]
+  (when-not (nil? (s :tail))
+    (for [t :in (s :tail)]
+      (gui/render (t :x) (t :y) " "))
+    (let [h (s :head)]
+      (gui/render (h :x) (h :y) " "))))
 
 (defn render-goal [goal]
   (gui/render (goal :x) (goal :y) (goal-icon :text) (goal-icon :style)))
@@ -83,6 +90,7 @@
       (if (l/collision-with-board? b (s :new))
         (render-game-over b (s :new)))
 
+      (clear-snake (s :old))
       (render-snake s2)
       (render-goal g2)
       (render-stats b s2)

--- a/src/game.phel
+++ b/src/game.phel
@@ -13,6 +13,9 @@
 
 (def board-width (l/get-from-list argv "width" 42))
 (def board-height (l/get-from-list argv "height" 22))
+(def board-offset-width "TODO: Not implemented yet" (l/get-from-list argv "x" 0))
+(def board-offset-height "TODO: Not implemented yet" (l/get-from-list argv "y" 0))
+
 (def debug? (php/in_array "debug" argv))
 (def nano-seconds-delay-base 140000)
 (def start-time (php/microtime true))
@@ -20,9 +23,10 @@
 (def snake-head-icon {:text " " :style "snake-head"})
 (def snake-tail-icon {:text " " :style "snake-tail"})
 
-(defn debug-snake [board snake]
-  (if debug? (do (gui/clear-line (+ 3 (board :height)))
-                 (gui/render 0 (+ 3 (board :height)) (str "# snake" snake)))))
+(defn debug-snake [b s]
+  (if debug? (do (gui/clear-line (+ 3 (b :height)))
+                 (let [text (str "$ " b "\n$ " s)]
+                   (println text)))))
 
 (defn sleep-delay [snake]
   (let [velocity (* (snake :speed) difficulty)
@@ -71,16 +75,18 @@
   (println (format "Speed: %d" (count (snake :tail))))
   (println (playing-time)))
 
+(def b (l/board board-offset-width board-offset-height board-width board-height))
+
 (defn main []
   (gui/clear-screen)
-  (loop [b (l/board board-width board-height)
-         s {:old {}
+  (gui/render-board b)
+
+  (loop [s {:old {}
             :new (l/snake :right 1 (l/generate-snake-head b) [])}
          g (l/generate-new-goal b)]
 
     (sleep-delay (s :new))
     (gui/clear-output)
-    (gui/render-board b)
 
     (let [{:hex in} (gui/read-input 3)
           next-direction (l/normalize-next-direction in)
@@ -99,7 +105,7 @@
       (let [new-goal? (not= g g2)
             s3 (if new-goal? (update s2 :speed inc) s2)
             s4 (if new-goal? (l/grow-snake s3) s3)]
-        (recur b {:old (s :new) :new s4} g2)))))
+        (recur {:old (s :new) :new s4} g2)))))
 
 (when-not *compile-mode*
   (try

--- a/src/logic.phel
+++ b/src/logic.phel
@@ -28,7 +28,7 @@
     # add head to the tail
     (update sn1 :tail |(push $ (snake :head)))))
 
-(defstruct board [width height])
+(defstruct board [offset-width offset-height width height])
 (defstruct snake [direction speed head tail])
 
 (defn dd

--- a/src/logic.phel
+++ b/src/logic.phel
@@ -23,19 +23,25 @@
     # add head to the tail
     (update sn1 :tail |(push $ (snake :head)))))
 
-(defn move-snake [snake next-direction]
+(defstruct board [width height])
+(defstruct snake [direction speed head tail])
+
+(defn dd
+  "Dump and die."
+  [x]
+  (println x)(php/die))
+
+(defn move-snake [s next-direction]
   (if (nil? next-direction)
-    (recur snake (snake :direction))
-    (let [sn1 (case next-direction
-                :left (update-in snake [:head :x] dec)
-                :right (update-in snake [:head :x] inc)
-                :up (update-in snake [:head :y] dec)
-                :down (update-in snake [:head :y] inc))
-          # remove the last tail position
-          sn2 (update sn1 :tail |(slice $ 1))
-          # add head to the tail
-          sn3 (update sn2 :tail |(push $ (snake :head)))]
-      (merge sn3 {:direction next-direction}))))
+    (recur s (s :direction))
+    (let [s2 (case next-direction
+               :left (update-in s [:head :x] dec)
+               :right (update-in s [:head :x] inc)
+               :up (update-in s [:head :y] dec)
+               :down (update-in s [:head :y] inc))
+          new-tail (push (drop 1 (s2 :tail)) (s :head))
+          s3 (put s2 :tail new-tail)]
+      (put s3 :direction next-direction))))
 
 (defn collision-with-board? [board snake]
   (or

--- a/src/logic.phel
+++ b/src/logic.phel
@@ -1,5 +1,10 @@
 (ns phel-snake\logic)
 
+(defn dd
+  "Dump and die."
+  [x]
+  (println x)(php/die))
+
 (def- key-left-arrow "1b5b44")
 (def- key-down-arrow "1b5b42")
 (def- key-right-arrow "1b5b43")
@@ -43,12 +48,12 @@
           s3 (put s2 :tail new-tail)]
       (put s3 :direction next-direction))))
 
-(defn collision-with-board? [board snake]
+(defn collision-with-board? [b s]
   (or
-   (>= 1 (get-in snake [:head :x]))
-   (>= 0 (get-in snake [:head :y]))
-   (= (board :width) (get-in snake [:head :x]))
-   (= (dec (board :height)) (get-in snake [:head :y]))))
+   (>= 1 (get-in s [:head :x]))
+   (>= 0 (get-in s [:head :y]))
+   (= (b :width) (get-in s [:head :x]))
+   (= (dec (b :height)) (get-in s [:head :y]))))
 
 (defn generate-new-goal [{:width width :height height}]
   (let [pos {:x (dec (rand-int width))
@@ -68,10 +73,10 @@
    (= (get-in snake [:head :x]) (goal :x))
    (= (get-in snake [:head :y]) (goal :y))))
 
-(defn update-goal [snake goal board]
-  (if (snake-reach-goal? snake goal)
-    (generate-new-goal board)
-    goal))
+(defn update-goal [s g b]
+  (if (snake-reach-goal? s g)
+    (generate-new-goal b)
+    g))
 
 (defn get-from-list [xs key default & [split]]
   (let [arg (find |(php/str_contains $ key) xs)]

--- a/src/logic.phel
+++ b/src/logic.phel
@@ -70,5 +70,5 @@
 (defn get-from-list [xs key default & [split]]
   (let [arg (find |(php/str_contains $ key) xs)]
     (if (empty? arg)
-        default
-        (php/intval (get (php/explode (or split "=") arg) 1)))))
+      default
+      (php/intval (get (php/explode (or split "=") arg) 1)))))

--- a/tests/logic-test.phel
+++ b/tests/logic-test.phel
@@ -21,8 +21,20 @@
            (move-snake s :down)))))
 
 (deftest test-grow-snake-right
-  (is (=             (snake :right 1 {:x 4 :y 5} [{:x 4 :y 5} {:x 5 :y 5}])
+  (is (= (snake :right 1 {:x 6 :y 5} [{:x 3 :y 5} {:x 4 :y 5} {:x 5 :y 5}])
          (grow-snake (snake :right 1 {:x 5 :y 5} [{:x 3 :y 5} {:x 4 :y 5}])))))
+
+(deftest test-grow-snake-left
+  (is (= (snake :left 1 {:x 4 :y 5} [{:x 3 :y 5} {:x 4 :y 5} {:x 5 :y 5}])
+         (grow-snake (snake :left 1 {:x 5 :y 5} [{:x 3 :y 5} {:x 4 :y 5}])))))
+
+(deftest test-grow-snake-up
+  (is (= (snake :up 1 {:x 5 :y 4} [{:x 3 :y 5} {:x 4 :y 5} {:x 5 :y 5}])
+         (grow-snake (snake :up 1 {:x 5 :y 5} [{:x 3 :y 5} {:x 4 :y 5}])))))
+
+(deftest test-grow-snake-down
+  (is (= (snake :down 1 {:x 5 :y 6} [{:x 3 :y 5} {:x 4 :y 5} {:x 5 :y 5}])
+         (grow-snake (snake :down 1 {:x 5 :y 5} [{:x 3 :y 5} {:x 4 :y 5}])))))
 
 (deftest test-snake-reach-goal?
   (let [goal {:x 2 :y 2}]

--- a/tests/logic-test.phel
+++ b/tests/logic-test.phel
@@ -1,6 +1,7 @@
 (ns phel-snake-tests\logic-test
   (:require phel-snake\logic :refer [snake
                                      snake-reach-goal?
+                                     grow-snake
                                      move-snake
                                      collision-with-board?
                                      get-from-list])
@@ -18,6 +19,10 @@
            (move-snake s :up)))
     (is (= (snake :down 1 {:x 5 :y 6} [{:x 4 :y 5} {:x 5 :y 5}])
            (move-snake s :down)))))
+
+(deftest test-grow-snake-right
+  (is (=             (snake :right 1 {:x 4 :y 5} [{:x 4 :y 5} {:x 5 :y 5}])
+         (grow-snake (snake :right 1 {:x 5 :y 5} [{:x 3 :y 5} {:x 4 :y 5}])))))
 
 (deftest test-snake-reach-goal?
   (let [goal {:x 2 :y 2}]

--- a/tests/logic-test.phel
+++ b/tests/logic-test.phel
@@ -1,34 +1,23 @@
 (ns phel-snake-tests\logic-test
-  (:require phel-snake\logic :refer [snake-reach-goal?
+  (:require phel-snake\logic :refer [snake
+                                     snake-reach-goal?
                                      move-snake
                                      collision-with-board?
                                      get-from-list])
   (:require phel\test :refer [deftest is]))
 
 (deftest test-move-snake
-  (let [snake {:head {:x 5 :y 5}
-               :direction :right
-               :tail [{:x 3 :y 5} {:x 4 :y 5}]}]
-    (is (= {:head {:x 6 :y 5}
-            :direction :right
-            :tail [{:x 4 :y 5} {:x 5 :y 5}]}
-           (move-snake snake nil)) "Keep the old direction if nil")
-    (is (= {:head {:x 4 :y 5}
-            :direction :left
-            :tail [{:x 4 :y 5} {:x 5 :y 5}]}
-           (move-snake snake :left)))
-    (is (= {:head {:x 6 :y 5}
-            :direction :right
-            :tail [{:x 4 :y 5} {:x 5 :y 5}]}
-           (move-snake snake :right)))
-    (is (= {:head {:x 5 :y 4}
-            :direction :up
-            :tail [{:x 4 :y 5} {:x 5 :y 5}]}
-           (move-snake snake :up)))
-    (is (= {:head {:x 5 :y 6}
-            :direction :down
-            :tail [{:x 4 :y 5} {:x 5 :y 5}]}
-           (move-snake snake :down)))))
+  (let  [s (snake :right 1 {:x 5 :y 5} [{:x 3 :y 5} {:x 4 :y 5}])]
+    (is (= (snake :right 1 {:x 6 :y 5} [{:x 4 :y 5} {:x 5 :y 5}])
+           (move-snake s nil)) "Keep the old direction if nil")
+    (is (= (snake :left 1 {:x 4 :y 5} [{:x 4 :y 5} {:x 5 :y 5}])
+           (move-snake s :left)))
+    (is (= (snake :right 1 {:x 6 :y 5} [{:x 4 :y 5} {:x 5 :y 5}])
+           (move-snake s :right)))
+    (is (= (snake :up 1 {:x 5 :y 4} [{:x 4 :y 5} {:x 5 :y 5}])
+           (move-snake s :up)))
+    (is (= (snake :down 1 {:x 5 :y 6} [{:x 4 :y 5} {:x 5 :y 5}])
+           (move-snake s :down)))))
 
 (deftest test-snake-reach-goal?
   (let [goal {:x 2 :y 2}]


### PR DESCRIPTION

## 📚 

Currently, as the board gets bigger, the rendering suffers lags, because it erases and draws every cell every time.
The gaol is to avoid lag and be able to play the game with any board size.

## 🔖 Changes

Save the old and new snake status in parallel, so when we need to redraw a new status, we simple erase the old status and render the new status, without the need of cleaning the whole board all the time. 
