### PR TITLE
Reproducing issue #571

### DIFF
--- a/src/full-version/game.phel
+++ b/src/full-version/game.phel
@@ -124,3 +124,6 @@
             snake3 (if new-goal? (update snake2 :speed inc) snake2)
             updated-snake (if new-goal? (l/grow-snake snake3) snake3)]
         (recur {:old (snake :current) :current updated-snake} updated-goal)))))
+
+(when-not *compile-mode*
+  (full-game))

--- a/src/main.phel
+++ b/src/main.phel
@@ -3,6 +3,8 @@
   (:require phel-snake\simple-version\game :refer [simple-game])
   (:require phel-snake\util :refer [get-from-list]))
 
+(php/die "This should kill the program")
+
 (when-not *compile-mode*
   (if (get-from-list argv "simple" false)
     (simple-game)

--- a/src/simple-version/game.phel
+++ b/src/simple-version/game.phel
@@ -75,3 +75,6 @@
       (render-snake new-snake)
       (php/usleep 50000)
       (recur new-snake))))
+
+(when-not *compile-mode*
+  (simple-game))


### PR DESCRIPTION
## Description

This branch is just to reproduce the issue: _require scope loads *build-mode* code_

Issue: https://github.com/phel-lang/phel-lang/issues/571

### How to reproduce?
```bash
vendor/bin/phel run src/main.phel
``` 

The program should display `This should kill the program`, however, it's running the "simple-game"